### PR TITLE
chg: dev: Using _register_shell.

### DIFF
--- a/lib/topology_docker_openswitch/openswitch.py
+++ b/lib/topology_docker_openswitch/openswitch.py
@@ -441,25 +441,38 @@ class OpenSwitchNode(DockerNode):
         # Add vtysh (default) shell
         # FIXME: Create a subclass to handle better the particularities of
         # vtysh, like prompt setup etc.
-        self._shells['vtysh'] = DockerShell(
-            self.container_id, 'vtysh', '(^|\n)switch(\([\-a-zA-Z0-9]*\))?#'
+        self._register_shell(
+            'vtysh',
+            DockerShell(
+                self.container_id, 'vtysh',
+                '(^|\n)switch(\([\-a-zA-Z0-9]*\))?#'
+            )
         )
 
         # Add bash shells
         initial_prompt = '(^|\n).*[#$] '
 
-        self._shells['bash'] = DockerBashShell(
-            self.container_id, 'bash',
-            initial_prompt=initial_prompt
+        self._register_shell(
+            'bash',
+            DockerBashShell(
+                self.container_id, 'bash',
+                initial_prompt=initial_prompt
+            )
         )
-        self._shells['bash_swns'] = DockerBashShell(
-            self.container_id, 'ip netns exec swns bash',
-            initial_prompt=initial_prompt
+        self._register_shell(
+            'bash_swns',
+            DockerBashShell(
+                self.container_id, 'ip netns exec swns bash',
+                initial_prompt=initial_prompt
+            )
         )
-        self._shells['vsctl'] = DockerBashShell(
-            self.container_id, 'bash',
-            initial_prompt=initial_prompt,
-            prefix='ovs-vsctl ', timeout=60
+        self._register_shell(
+            'vsctl',
+            DockerBashShell(
+                self.container_id, 'bash',
+                initial_prompt=initial_prompt,
+                prefix='ovs-vsctl ', timeout=60
+            )
         )
 
     def notify_post_build(self):


### PR DESCRIPTION
This is necessary to make shells register with the node and get
information necessary to log properly in the pexpect file.
