### PR TITLE
fix: dev: Increasing config timeout.

### DIFF
--- a/lib/topology_docker_openswitch/openswitch.py
+++ b/lib/topology_docker_openswitch/openswitch.py
@@ -52,7 +52,7 @@ from socket import AF_UNIX, SOCK_STREAM, socket, gethostname
 import re
 import yaml
 
-config_timeout = 300
+config_timeout = 1200
 ops_switchd_active_timeout = 60
 swns_netns = '/var/run/netns/swns'
 emulns_netns = '/var/run/netns/emulns'


### PR DESCRIPTION
New ubuntu 16.04 VMs are slower when bringing the container causing a large amount of timeouts which were false positives. 
