### PR TITLE
fix: dev: Change P4 boot to accept string labels

### DIFF
--- a/lib/topology_docker_openswitch/openswitch_setup
+++ b/lib/topology_docker_openswitch/openswitch_setup
@@ -116,7 +116,7 @@ def create_interfaces():
                     '/usr/share/ovs_p4_plugin/switch_bmv2.json '
                     '--thrift-port 10001'.format(
                         ns_exec=ns_exec, hwport=hwport,
-                        port=str(int(hwport) - 1)
+                        port=str(int(len(mapping_ports.keys())) - 1)
                     ),
                     shell=True
                 )


### PR DESCRIPTION
Modified P4 boot logic to accept port names in any format
when mapping them to interface labels