### PR TITLE
Remove switch container volume mount dev/log

### DIFF
--- a/lib/topology_docker_openswitch/openswitch.py
+++ b/lib/topology_docker_openswitch/openswitch.py
@@ -112,7 +112,6 @@ class DockerOpenSwitch(OpenSwitchBase, DockerNode):
 
         # Add binded directories
         container_binds = [
-            '/dev/log:/dev/log',
             '/sys/fs/cgroup:/sys/fs/cgroup'
         ]
         if binds is not None:


### PR DESCRIPTION
This mount was used to gather logs from containers and log them in the
execution machine, it was an old practice from first topology days and
is not required anymore.

The removal is mainly because there are some vtysh commands that extract
data from local log files, so the logs need to be on the container instead
of the execution machine.